### PR TITLE
Trial license support

### DIFF
--- a/CloudFormation/public-sample-single-server.cfn
+++ b/CloudFormation/public-sample-single-server.cfn
@@ -96,15 +96,6 @@
         "Description" : "The availability zone in which our server and storage volume reside",
         "Type": "AWS::EC2::AvailabilityZone::Name"
     },
-    "RunasPassword" : {
-      "Description" : "The password of the user which runs the service; blank for default",
-      "Type" : "String",
-      "NoEcho" : "true"
-    },
-    "RunasUser" : {
-      "Description" : "The name of the user which runs the service; blank for default",
-      "Type" : "String"
-    },
     "SourceCidrForRDP" : {
       "Description" : "IP Cidr from which you are likely to RDP into the instances. You can add rules later by modifying the created security groups e.g. 54.32.98.160/32",
       "Type" : "String",
@@ -202,7 +193,7 @@
         },
         {
             "Label" : { "default" : "Secrets" },
-            "Parameters" : ["RunasUser","RunasPassword","ContentAdminUser","ContentAdminPassword"]
+            "Parameters" : ["ContentAdminUser","ContentAdminPassword"]
         },
         {
             "Label" : { "default" : "Registration" },
@@ -278,12 +269,6 @@
         },
         "ResourceAvailabilityZone": {
             "default": "Target AZ"
-        },
-        "RunasPassword": {
-            "default": "Service runas password"
-        },
-        "RunasUser": {
-            "default": "Service runas user"
         },
         "SourceCidrForRDP": {
             "default": "Allowed CIDR for RDP access"
@@ -457,8 +442,6 @@
               },
               "c:\\tabsetup\\secrets.json" : {
                 "content" : {
-                    "runas_user" : {"Ref" : "RunasUser"},
-                    "runas_pass" : {"Ref" : "RunasPassword"},
                     "content_admin_user" : {"Ref" : "ContentAdminUser"},
                     "content_admin_pass" : {"Ref" : "ContentAdminPassword"}
                 }

--- a/CloudFormation/public-sample-single-server.cfn
+++ b/CloudFormation/public-sample-single-server.cfn
@@ -25,8 +25,8 @@
     "InstanceType" : {
       "Description" : "Amazon EC2 instance type",
       "Type" : "String",
-      "Default" : "m4.xlarge",
-      "AllowedValues" : [ "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge"],
+      "Default" : "m4.4xlarge",
+      "AllowedValues" : [ "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.8xlarge", "r4.xlarge", "r4.2xlarge", "r4.4xlarge", "r4.8xlarge"],
       "ConstraintDescription" : "must be a valid EC2 instance type."
     },
     "KeyPairName" : {
@@ -124,10 +124,10 @@
       "MinLength" : "1"
     },
     "TableauServerVolumeSize" : {
-      "Description" : "Size of volume for server in GB; need at least 30 meg free for server installation",
+      "Description" : "Size of volume for server in GB; need at least 30 GB free for server installation",
       "Type" : "Number",
       "Default" : "100",
-      "MinValue" : "60"
+      "MinValue" : "30"
     },
     "WindowsVersion" : {
       "Description" : "The version of Windows to use",
@@ -283,7 +283,7 @@
             "default": "Server installer executable"
         },
         "TableauServerLicenseKey": {
-            "default": "Tableau Activation Key"
+            "Description": "License Key (leave blank for trial)",
         },
         "TableauServerVolumeSize": {
             "default": "Size for server volume in GB; Requires at least 30 GB"
@@ -365,7 +365,8 @@
     }
   },
   "Conditions" : {
-    "EnablePublicFirewallRule" : { "Fn::Equals" : [ {"Ref" : "PublicFirewallProfileHole"},"Yes"]}
+    "EnablePublicFirewallRule" : { "Fn::Equals" : [{ "Ref" : "PublicFirewallProfileHole"},"Yes"]},
+    "IsTrial" :                  { "Fn::Equals":  [{ "Ref" : "TableauServerLicenseKey", "" }]
   },
   "Resources" : {
     "InstanceSecurityGroup" : {
@@ -506,12 +507,19 @@
                   "c:\\Python27\\python.exe",
                   "ScriptedInstaller.py", "install",
                   "--installerLog", "C:\\tabsetup\\tabinstall.txt",
-                  "--installDir C:\\TableauServer",
                   { "Fn::If" : [ "EnablePublicFirewallRule", "--enablePublicFwRule", ""]},
                   "--secretsFile c:\\tabsetup\\secrets.json",
                   "--configFile c:\\tabsetup\\config.yml",
                   "--registrationFile c:\\tabsetup\\registration.json",
-                  "--licenseKey", { "Ref" : "TableauServerLicenseKey"},
+                  {
+                    "Fn::If": [
+                        "IsTrial",
+                        "--trialLicense",
+                        {
+                            "Fn::Sub": "--licenseKey ${TableauServerLicenseKey}"
+                        }
+                    ]
+                  },
                   "c:\\tabsetup\\tableau-server-installer.exe",
                   " > c:\\tabsetup\\installer-output.txt 2>&1"
                   ]]

--- a/CloudFormation/public-sample-single-server.cfn
+++ b/CloudFormation/public-sample-single-server.cfn
@@ -18,7 +18,6 @@
       "Type" : "String",
       "MinLength" : "9",
       "MaxLength" : "18",
-      "Default": "0.0.0.0/0",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
     },
@@ -27,7 +26,6 @@
       "Type" : "String",
       "MinLength" : "9",
       "MaxLength" : "18",
-      "Default": "0.0.0.0/0",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
     },
@@ -53,19 +51,17 @@
     "WindowsVersion" : {
       "Description" : "The version of Windows to use",
       "Type" : "String",
-      "Default" : "Windows2012r2",
-      "AllowedValues" : ["Windows2012r2"],
-      "ConstraintDescription" : "must be one of : Windows2012r2"
+      "Default" : "WS2012R2",
+      "AllowedValues" : ["WS2012R2"],
+      "ConstraintDescription" : "must be one of : WS2012R2"
     },
     "RunasUser" : {
       "Description" : "The name of the user which runs the service; blank for default",
-      "Type" : "String",
-      "Default" : ""
+      "Type" : "String"
     },
     "RunasPassword" : {
       "Description" : "The password of the user which runs the service; blank for default",
       "Type" : "String",
-      "Default" : "",
       "NoEcho" : "true"
     },
     "ContentAdminUser" : {
@@ -229,10 +225,52 @@
     }
   },
   "Mappings" : {
-    "AWSRegion2AMI" : {
-      "us-east-1"        : { "Windows2012r2" : "ami-ee7805f9"},
-      "us-west-2"        : { "Windows2012r2" : "ami-2827f548"},
-      "us-west-1"        : { "Windows2012r2" : "ami-c06b24a0"}
+    "AWSAMIRegionMap": {
+        "AMI": {
+            "WS2012R2": "Windows_Server-2012-R2_RTM-English-64Bit-Base-2016.11.23"
+        },
+        "ap-northeast-1": {
+            "WS2012R2": "ami-5b299d3a"
+        },
+        "ap-northeast-2": {
+            "WS2012R2": "ami-69d30407"
+        },
+        "ap-south-1": {
+            "WS2012R2": "ami-79255216"
+        },
+        "ap-southeast-1": {
+            "WS2012R2": "ami-9d7ad8fe"
+        },
+        "ap-southeast-2": {
+            "WS2012R2": "ami-9fe7d9fc"
+        },
+        "ca-central-1": {
+            "WS2012R2": "ami-f57fcd91"
+        },
+        "eu-central-1": {
+            "WS2012R2": "ami-21cb0f4e"
+        },
+        "eu-west-1": {
+            "WS2012R2": "ami-95d984e6"
+        },
+        "eu-west-2": {
+            "WS2012R2": "ami-bb353fdf"
+        },
+        "sa-east-1": {
+            "WS2012R2": "ami-628e100e"
+        },
+        "us-east-1": {
+            "WS2012R2": "ami-bfeddca8"
+        },
+        "us-east-2": {
+            "WS2012R2": "ami-e999c38c"
+        },
+        "us-west-1": {
+            "WS2012R2": "ami-8b590deb"
+        },
+        "us-west-2": {
+            "WS2012R2": "ami-24e64944"
+        }
     }
   },
   "Conditions" : {
@@ -271,11 +309,6 @@
                               "Effect": "Allow",
                               "Action": ["s3:GetObject"],
                               "Resource": {"Fn::Sub" : "arn:aws:s3:::${InstallationBucket}/*"}
-                            },
-                            {
-                              "Effect": "Allow",
-                              "Action": [ "s3:ListBucket"],
-                              "Resource": {"Fn::Sub" : "arn:aws:s3:::${InstallationBucket}"}
                             }
                           ]
                     }
@@ -360,30 +393,6 @@
               },
               "c:\\tabsetup\\tableau-server-installer.exe" : {
                 "source":  { "Fn::Sub" : "https://${InstallationBucket}.s3.amazonaws.com/${TableauServerInstaller}"}
-              },
-              "c:\\tabsetup\\send-done-signal.cmd" : {
-                "content" : { "Fn::Join" : ["\n", [
-                    "@echo off",
-                    "if not exist c:\\tabsetup\\installer-output.txt goto no_installer_output",
-                    "SetLocal EnableDelayedExpansion",
-                    "set content=",
-                    "for /F \"delims=\" %%i in (c:\\tabsetup\\installer-output.txt) do set content=!content! %%i",
-                    { "Fn::Sub" : ["cfn-signal.exe --reason \"Installer failed\" --data \"%content%\" -e %1 ${WHUrl}",
-                            {
-                                "WHUrl" : { "Fn::Base64" : { "Ref" : "TableauServerWaitHandle"}}
-                            }]
-                    },
-                    "EndLocal",
-                    "goto alldone",
-                    ":no_installer_output",
-                    { "Fn::Sub" : ["cfn-signal.exe -e %1 ${WHUrl}",
-                            {
-                                "WHUrl" : { "Fn::Base64" : { "Ref" : "TableauServerWaitHandle"}}
-                            }]
-                    },
-                    ":alldone",
-                    "exit /B %1"
-                ]]}
               }
             },
             "commands" : {
@@ -439,7 +448,7 @@
       
       "Properties": {
         "InstanceType" : { "Ref" : "InstanceType" },
-        "ImageId" : { "Fn::FindInMap" : [ "AWSRegion2AMI", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
+        "ImageId" : { "Fn::FindInMap" : [ "AWSAMIRegionMap", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
         "AvailabilityZone" : { "Ref" : "ResourceAvailabilityZone" },
         "BlockDeviceMappings" : [
            { 
@@ -450,10 +459,10 @@
         "SecurityGroups" : [ {"Ref" : "InstanceSecurityGroup"} ],
         "IamInstanceProfile" : { "Ref" : "TableauWindowsServerInstanceProfile" },
         "KeyName" : { "Ref" : "KeyName" },
-        "UserData" : { "Fn::Base64" : { "Fn::Join" : ["\n", [
-            "<script>",
-            { "Fn::Sub" : "cfn-init.exe -v -s ${AWS::StackId} -r TableauWindowsServer --region ${AWS::Region}"},
-            "c:\\tabsetup\\send-done-signal.cmd %errorlevel%",
+        "UserData" : { "Fn::Base64" : { "Fn::Join" : ["", [
+            "<script>\n",
+            { "Fn::Sub" : "cfn-init.exe -v -s ${AWS::StackId} -r TableauWindowsServer --region ${AWS::Region}\n"},
+            { "Fn::Sub" : "cfn-signal.exe -e %ERRORLEVEL% --stack ${AWS::StackName} --resource TableauWindowsServer --region ${AWS::Region}\n"},
              "</script>"
         ]]}},
         "Tags": [
@@ -461,17 +470,11 @@
                 "Key" : "Name",
                 "Value" : {"Fn::Sub" : "cfn-tableau-server"}
             }
-        ]
-        }
-    },
-    "TableauServerWaitHandle" : {
-        "Type" : "AWS::CloudFormation::WaitConditionHandle"
-    },
-    "TableauServerWaitCondition" : {
-        "Type" : "AWS::CloudFormation::WaitCondition",
-        "Properties" : {
-            "Handle" : { "Ref" : "TableauServerWaitHandle" },
-            "Timeout" : "3600"
+        ]},
+        "CreationPolicy" : {
+            "ResourceSignal" : {
+                "Timeout" : "PT60M"
+            }
         }
     }
   },

--- a/CloudFormation/public-sample-single-server.cfn
+++ b/CloudFormation/public-sample-single-server.cfn
@@ -283,10 +283,10 @@
             "default": "Server installer executable"
         },
         "TableauServerLicenseKey": {
-            "Description": "License Key (leave blank for trial)",
+            "default": "License Key (leave blank for trial)",
         },
         "TableauServerVolumeSize": {
-            "default": "Size for server volume in GB; Requires at least 30 GB"
+            "default": "Size for server volume in GB"
         },
         "WindowsVersion": {
             "default": "Server OS Version"

--- a/CloudFormation/public-sample-single-server.cfn
+++ b/CloudFormation/public-sample-single-server.cfn
@@ -4,30 +4,17 @@
   "Description" : "Create a Tableau Server instance running on Windows",
 
   "Parameters" : {
-    "KeyName" : {
-      "Description" : "Name of an existing EC2 KeyPair used to get the Administrator password for the instance",
-      "Type" : "AWS::EC2::KeyPair::KeyName",
-      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
-    },
-    "ResourceAvailabilityZone" : {
-        "Description" : "The availability zone in which our server and storage volume reside",
-        "Type": "AWS::EC2::AvailabilityZone::Name"
-    },
-    "SourceCidrForRDP" : {
-      "Description" : "IP Cidr from which you are likely to RDP into the instances. You can add rules later by modifying the created security groups e.g. 54.32.98.160/32",
+    "ContentAdminPassword" : {
+      "Description" : "The password for the initial Admin user for Tableau server",
       "Type" : "String",
-      "MinLength" : "9",
-      "MaxLength" : "18",
-      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
+      "MinLength" : "1",
+      "NoEcho" : "true"
     },
-    "SourceCidrForWeb" : {
-      "Description" : "IP Cidr for Web clients. This can be a specific subnet (yours), or open to the world. 0.0.0.0/0",
+    "ContentAdminUser" : {
+      "Description" : "The name of the initial Admin user for Tableau server",
       "Type" : "String",
-      "MinLength" : "9",
-      "MaxLength" : "18",
-      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
+      "Default" : "admin",
+      "MinLength" : "1"
     },
     "InstallationBucket" : {
       "Description" : "The name of the S3 bucket from which to fetch the server installer",
@@ -42,44 +29,17 @@
       "AllowedValues" : [ "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge"],
       "ConstraintDescription" : "must be a valid EC2 instance type."
     },
-    "TableauServerVolumeSize" : {
-      "Description" : "Size of volume for server in GB; need at least 30 meg free for server installation",
-      "Type" : "Number",
-      "Default" : "100",
-      "MinValue" : "60"
+    "KeyPairName" : {
+      "Description" : "Name of an existing EC2 KeyPair used to get the Administrator password for the instance",
+      "Type" : "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
     },
-    "WindowsVersion" : {
-      "Description" : "The version of Windows to use",
+    "PublicFirewallProfileHole": {
+      "Description" : "If firewall rules are created allowing access to the server, create rule allowing access via the Public profile (useful for AWS)",
       "Type" : "String",
-      "Default" : "WS2012R2",
-      "AllowedValues" : ["WS2012R2"],
-      "ConstraintDescription" : "must be one of : WS2012R2"
-    },
-    "RunasUser" : {
-      "Description" : "The name of the user which runs the service; blank for default",
-      "Type" : "String"
-    },
-    "RunasPassword" : {
-      "Description" : "The password of the user which runs the service; blank for default",
-      "Type" : "String",
-      "NoEcho" : "true"
-    },
-    "ContentAdminUser" : {
-      "Description" : "The name of the initial Admin user for Tableau server",
-      "Type" : "String",
-      "Default" : "admin",
-      "MinLength" : "1"
-    },
-    "ContentAdminPassword" : {
-      "Description" : "The password for the initial Admin user for Tableau server",
-      "Type" : "String",
-      "MinLength" : "1",
-      "NoEcho" : "true"
-    },
-    "TableauServerLicenseKey" : {
-      "Description" : "License Key",
-      "Type" : "String",
-      "MinLength" : "1"
+      "Default" : "Yes",
+      "AllowedValues" : ["Yes", "No"],
+      "ConstraintDescription" : "must be one of Yes , No"
     },
     "RegFirstName" : {
       "Description" : "First Name",
@@ -132,18 +92,58 @@
       "Description" : "Country",
       "Type" : "String"
     },
+    "ResourceAvailabilityZone" : {
+        "Description" : "The availability zone in which our server and storage volume reside",
+        "Type": "AWS::EC2::AvailabilityZone::Name"
+    },
+    "RunasPassword" : {
+      "Description" : "The password of the user which runs the service; blank for default",
+      "Type" : "String",
+      "NoEcho" : "true"
+    },
+    "RunasUser" : {
+      "Description" : "The name of the user which runs the service; blank for default",
+      "Type" : "String"
+    },
+    "SourceCidrForRDP" : {
+      "Description" : "IP Cidr from which you are likely to RDP into the instances. You can add rules later by modifying the created security groups e.g. 54.32.98.160/32",
+      "Type" : "String",
+      "MinLength" : "9",
+      "MaxLength" : "18",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
+    },
+    "SourceCidrForWeb" : {
+      "Description" : "IP Cidr for Web clients. This can be a specific subnet (yours), or open to the world. 0.0.0.0/0",
+      "Type" : "String",
+      "MinLength" : "9",
+      "MaxLength" : "18",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
+    },
     "TableauServerInstaller" : {
       "Description" : "Installer to use",
       "Type" : "String",
       "Default" : "Setup-Server-x64.exe",
       "MinLength" : "1"
     },
-    "PublicFirewallProfileHole": {
-      "Description" : "If firewall rules are created allowing access to the server, create rule allowing access via the Public profile (useful for AWS)",
+    "TableauServerLicenseKey" : {
+      "Description" : "License Key",
       "Type" : "String",
-      "Default" : "No",
-      "AllowedValues" : ["Yes", "No"],
-      "ConstraintDescription" : "must be one of Yes , No"
+      "MinLength" : "1"
+    },
+    "TableauServerVolumeSize" : {
+      "Description" : "Size of volume for server in GB; need at least 30 meg free for server installation",
+      "Type" : "Number",
+      "Default" : "100",
+      "MinValue" : "60"
+    },
+    "WindowsVersion" : {
+      "Description" : "The version of Windows to use",
+      "Type" : "String",
+      "Default" : "WS2012R2",
+      "AllowedValues" : ["WS2012R2"],
+      "ConstraintDescription" : "must be one of : WS2012R2"
     },
     "Worker0GatewayPort" : {
       "Description" : "Web port for Tableau gateway",
@@ -194,7 +194,7 @@
       "ParameterGroups" : [
         {
             "Label" : { "default" : "AWS Environment" },
-            "Parameters" : ["KeyName","ResourceAvailabilityZone","SourceCidrForRDP","SourceCidrForWeb", "InstallationBucket"]
+            "Parameters" : ["KeyPairName","ResourceAvailabilityZone","SourceCidrForRDP","SourceCidrForWeb", "InstallationBucket"]
         },
         {
             "Label" : { "default" : "Machine Configuration" },
@@ -221,7 +221,113 @@
             "Parameters" : [ "TableauServerInstaller" ]
         }
       ],
-      "ParameterLabels" : {}
+      "ParameterLabels" : {
+        "ContentAdminPassword": {
+            "default": "Portal admin password"
+        },
+        "ContentAdminUser": {
+            "default": "Portal admin username"
+        },
+        "InstallationBucket": {
+            "default": "Source S3 Bucket"
+        },
+        "InstanceType": {
+            "default": "Tableau Server EC2 Instance Type"
+        },
+        "KeyPairName": {
+            "default": "Key Pair Name"
+        },
+        "PublicFirewallProfileHole": {
+            "default": "Windows firewall rules also apply to the Public profile"
+        },
+        "RegFirstName": {
+            "default": "First Name"
+        },
+        "RegLastName": {
+            "default": "Last name"
+        },
+        "RegEmail": {
+            "default": "Email Address"
+        },
+        "RegCompany": {
+            "default": "Company"
+        },
+        "RegTitle": {
+            "default": "Title"
+        },
+        "RegDepartment": {
+            "default": "Department"
+        },
+        "RegIndustry": {
+            "default": "Industry"
+        },
+        "RegPhone": {
+            "default": "Phone"
+        },
+        "RegCity": {
+            "default": "City"
+        },
+        "RegState": {
+            "default": "State"
+        },
+        "RegZip": {
+            "default": "Zip/Postal Code"
+        },
+        "RegCountry": {
+            "default": "Country"
+        },
+        "ResourceAvailabilityZone": {
+            "default": "Target AZ"
+        },
+        "RunasPassword": {
+            "default": "Service runas password"
+        },
+        "RunasUser": {
+            "default": "Service runas user"
+        },
+        "SourceCidrForRDP": {
+            "default": "Allowed CIDR for RDP access"
+        },
+        "SourceCidrForWeb": {
+            "default": "Allowed CIDR for access to the Web UI"
+        },
+        "SSLCertificateARN": {
+            "default": "SSL certificate ARN (Requires mattching DNS name)"
+        },
+        "TableauServerInstaller": {
+            "default": "Server installer executable"
+        },
+        "TableauServerLicenseKey": {
+            "default": "Tableau Activation Key"
+        },
+        "TableauServerVolumeSize": {
+            "default": "Size for server volume in GB; Requires at least 30 GB"
+        },
+        "WindowsVersion": {
+            "default": "Server OS Version"
+        },
+        "Worker0GatewayPort": {
+            "default": "Gateway (web) port"
+        },
+        "Worker0BackgrounderProcs": {
+            "default": "Number of Backgrounder processes"
+        },
+        "Worker0CacheserverProcs": {
+            "default": "Number of CacheServer processes"
+        },
+        "Worker0DataengineProcs": {
+            "default": "Numnber of Data Engine processes"
+        },
+        "Worker0DataserverProcs": {
+            "default": "Numnber of Data Server processes"
+        },
+        "Worker0VizportalProcs": {
+            "default": "Number of Vizportal processes"
+        },
+        "Worker0VizqlserverProcs": {
+            "default": "Number of VizqlServer processes"
+        }
+      }
     }
   },
   "Mappings" : {
@@ -458,7 +564,7 @@
         ],
         "SecurityGroups" : [ {"Ref" : "InstanceSecurityGroup"} ],
         "IamInstanceProfile" : { "Ref" : "TableauWindowsServerInstanceProfile" },
-        "KeyName" : { "Ref" : "KeyName" },
+        "KeyName" : { "Ref" : "KeyPairName" },
         "UserData" : { "Fn::Base64" : { "Fn::Join" : ["", [
             "<script>\n",
             { "Fn::Sub" : "cfn-init.exe -v -s ${AWS::StackId} -r TableauWindowsServer --region ${AWS::Region}\n"},

--- a/CloudFormation/public-sample-single-server.cfn
+++ b/CloudFormation/public-sample-single-server.cfn
@@ -282,7 +282,7 @@
             "default": "Server installer executable"
         },
         "TableauServerLicenseKey": {
-            "default": "License Key (leave blank for trial)",
+            "default": "License Key (leave blank for trial)"
         },
         "TableauServerVolumeSize": {
             "default": "Size for server volume in GB"
@@ -365,7 +365,7 @@
   },
   "Conditions" : {
     "EnablePublicFirewallRule" : { "Fn::Equals" : [{ "Ref" : "PublicFirewallProfileHole"},"Yes"]},
-    "IsTrial" :                  { "Fn::Equals":  [ "", { "Ref" : "TableauServerLicenseKey" }]
+    "IsTrial" :                  { "Fn::Equals":  [ "", { "Ref" : "TableauServerLicenseKey" }]},
   },
   "Resources" : {
     "InstanceSecurityGroup" : {
@@ -579,10 +579,6 @@
         "Description" : "EC2 InstanceID of the instance running Tableau Server",
         "Value" : { "Ref" : "TableauWindowsServer" }
     },
-    "PublicIpAddress" : {
-        "Description" : "Public IP Address of instance running Tableau Server",
-        "Value" : { "Fn::GetAtt" : [ "TableauWindowsServer", "PublicIp"]}
-    },
     "PublicDNSName" : {
         "Description" : "Public DNS name of instance running Tableau Server",
         "Value" : { "Fn::GetAtt" : [ "TableauWindowsServer", "PublicDnsName"]}
@@ -590,6 +586,6 @@
     "PublicGatewayPort" : {
         "Description" : "The port serving web traffic on the public interface of Tableau Server",
         "Value" : {"Ref" : "Worker0GatewayPort"}
-    },
+    }
   }    
 }

--- a/CloudFormation/public-sample-single-server.cfn
+++ b/CloudFormation/public-sample-single-server.cfn
@@ -120,8 +120,7 @@
     },
     "TableauServerLicenseKey" : {
       "Description" : "License Key",
-      "Type" : "String",
-      "MinLength" : "1"
+      "Type" : "String"
     },
     "TableauServerVolumeSize" : {
       "Description" : "Size of volume for server in GB; need at least 30 GB free for server installation",
@@ -366,7 +365,7 @@
   },
   "Conditions" : {
     "EnablePublicFirewallRule" : { "Fn::Equals" : [{ "Ref" : "PublicFirewallProfileHole"},"Yes"]},
-    "IsTrial" :                  { "Fn::Equals":  [{ "Ref" : "TableauServerLicenseKey", "" }]
+    "IsTrial" :                  { "Fn::Equals":  [ "", { "Ref" : "TableauServerLicenseKey" }]
   },
   "Resources" : {
     "InstanceSecurityGroup" : {

--- a/CloudFormation/public-sample-ssl-cluster.cfn
+++ b/CloudFormation/public-sample-ssl-cluster.cfn
@@ -295,8 +295,7 @@
             "EnableDnsSupport" : "true",
             "EnableDnsHostnames" : "true",
             "Tags" : [ 
-                {"Key" : "Name", "Value" : "ClusterVPC"}, 
-                {"Key" : "CreatedBy", "Value" : "jcase@tableau.com"}
+                {"Key" : "Name", "Value" : "ClusterVPC"}
             ]
         }
     },
@@ -304,8 +303,7 @@
         "Type" : "AWS::EC2::InternetGateway",
         "Properties" : {
             "Tags" : [ 
-                {"Key" : "Name", "Value" : "ClusterInternetGateway"}, 
-                {"Key" : "CreatedBy", "Value" : "jcase@tableau.com"}
+                {"Key" : "Name", "Value" : "ClusterInternetGateway"}
             ]
         }
     },
@@ -336,8 +334,7 @@
         "Properties" : {
             "VpcId" : { "Ref" : "ClusterVPC" },
             "Tags" : [
-                {"Key" : "Name", "Value" : "MainRouteTable"}, 
-                {"Key" : "CreatedBy", "Value" : "jcase@tableau.com"}
+                {"Key" : "Name", "Value" : "MainRouteTable"}
             ]
         }
     },
@@ -361,8 +358,7 @@
         "Properties" : {
             "VpcId" : { "Ref" : "ClusterVPC" },
             "Tags" : [
-                {"Key" : "Name", "Value" : "PrivateRouteTable"}, 
-                {"Key" : "CreatedBy", "Value" : "jcase@tableau.com"}
+                {"Key" : "Name", "Value" : "PrivateRouteTable"}
             ]
         }
     },
@@ -388,8 +384,7 @@
             "CidrBlock" : "10.0.0.0/24",
             "MapPublicIpOnLaunch" : "true",
             "Tags" : [ 
-                {"Key" : "Name", "Value" : "jcase cluster public subnet"}, 
-                {"Key" : "CreatedBy", "Value" : "jcase@tableau.com"}
+                {"Key" : "Name", "Value" : "cluster public subnet"}
             ],
             "VpcId" : { "Ref" : "ClusterVPC" }
         }
@@ -401,8 +396,7 @@
             "CidrBlock" : "10.0.1.0/24",
             "MapPublicIpOnLaunch" : "false",
             "Tags" : [ 
-                {"Key" : "Name", "Value" : "jcase cluster private subnet"}, 
-                {"Key" : "CreatedBy", "Value" : "jcase@tableau.com"}
+                {"Key" : "Name", "Value" : "cluster private subnet"}
             ],
             "VpcId" : { "Ref" : "ClusterVPC" }
         }
@@ -420,8 +414,7 @@
           }
         ],
         "Tags" : [
-            {"Key" : "Name", "Value" : "BastionSecurityGroup"}, 
-            {"Key" : "CreatedBy", "Value" : "jcase@tableau.com"}
+            {"Key" : "Name", "Value" : "BastionSecurityGroup"} 
         ],
         "VpcId" : { "Ref" : "ClusterVPC" }
       }
@@ -455,8 +448,7 @@
             }
         ],
         "Tags" : [
-            {"Key" : "Name", "Value" : "InternalSecurityGroup"}, 
-            {"Key" : "CreatedBy", "Value" : "jcase@tableau.com"}
+            {"Key" : "Name", "Value" : "InternalSecurityGroup"}
         ],
         "VpcId": { "Ref" : "ClusterVPC" }
       }
@@ -474,8 +466,7 @@
           }
         ],
         "Tags" : [
-            {"Key" : "Name", "Value" : "LoadBalancerSecurityGroup"}, 
-            {"Key" : "CreatedBy", "Value" : "jcase@tableau.com"}
+            {"Key" : "Name", "Value" : "LoadBalancerSecurityGroup"}
         ],
         "VpcId" : { "Ref" : "ClusterVPC" }
       }

--- a/CloudFormation/public-sample-ssl-cluster.cfn
+++ b/CloudFormation/public-sample-ssl-cluster.cfn
@@ -257,7 +257,7 @@
             "default": "Primary installer executable"
         },
         "TableauServerVolumeSize": {
-            "default": "Size for server volume in GB; Requires at least 30 GB"
+            "default": "Size for server volume in GB"
         },
         "TableauServerWorkerInstaller": {
             "default": "Worker installer executable"

--- a/CloudFormation/public-sample-ssl-cluster.cfn
+++ b/CloudFormation/public-sample-ssl-cluster.cfn
@@ -114,15 +114,6 @@
         "Description" : "The availability zone (AZ) in which our server and storage volume reside",
         "Type": "AWS::EC2::AvailabilityZone::Name"
     },
-    "RunasPassword" : {
-      "Description" : "The password of the user which runs the Windows services; blank for default",
-      "Type" : "String",
-      "NoEcho" : "true"
-    },
-    "RunasUser" : {
-      "Description" : "The name of the user which runs the Windows service; blank for default",
-      "Type" : "String"
-    },
     "SSLCertificateARN" : {
         "Description" : "The Amazon Resource Name for the existing SSL cert you wish to use",
         "Type" : "String"
@@ -173,7 +164,7 @@
         },
         {
             "Label" : { "default" : "Secrets" },
-            "Parameters" : ["RunasUser","RunasPassword","ContentAdminUser","ContentAdminPassword"]
+            "Parameters" : ["ContentAdminUser","ContentAdminPassword"]
         },
         {
             "Label" : { "default" : "Registration" },
@@ -249,12 +240,6 @@
         },
         "ResourceAvailabilityZone": {
             "default": "Target AZ"
-        },
-        "RunasPassword": {
-            "default": "Service runas password"
-        },
-        "RunasUser": {
-            "default": "Service runas user"
         },
         "SSLCertificateARN": {
             "default": "SSL certificate ARN (Requires mattching DNS name)"
@@ -640,8 +625,6 @@
                         },
                         "c:\\tabsetup\\secrets.json" : {
                             "content" : {
-                                "runas_user" : {"Ref" : "RunasUser"},
-                                "runas_pass" : {"Ref" : "RunasPassword"},
                                 "content_admin_user" : {"Ref" : "ContentAdminUser"},
                                 "content_admin_pass" : {"Ref" : "ContentAdminPassword"}
                             }

--- a/CloudFormation/public-sample-ssl-cluster.cfn
+++ b/CloudFormation/public-sample-ssl-cluster.cfn
@@ -13,19 +13,6 @@
         "Type" : "String",
         "MinLength" : "1"
     },
-    "SSLCertificateARN" : {
-        "Description" : "The Amazon Resource Name for the existing SSL cert you wish to use",
-        "Type" : "String"
-    },
-    "KeyName" : {
-      "Description" : "Name of an existing EC2 KeyPair used to get the Administrator password for the instance",
-      "Type" : "AWS::EC2::KeyPair::KeyName",
-      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
-    },
-    "ResourceAvailabilityZone" : {
-        "Description" : "The availability zone (AZ) in which our server and storage volume reside",
-        "Type": "AWS::EC2::AvailabilityZone::Name"
-    },
     "BastionCidrForRDP" : {
       "Description" : "CIDR from which you may RDP into the bastion host (e.g., 1.1.1.1/32)",
       "Type" : "String",
@@ -34,41 +21,10 @@
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
     },
-    "LoadBalancerCidrForWeb" : {
-      "Description" : "CIDR for Web clients. This can be a specific subnet (yours), or open to the world. (e.g., 0.0.0.0/0)",
+    "ContentAdminPassword" : {
+      "Description" : "The password for the initial Admin user for Tableau server",
       "Type" : "String",
-      "MinLength" : "9",
-      "MaxLength" : "18",
-      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
-    },
-    "InstanceType" : {
-      "Description" : "EC2 instance type for Tableau Server instances",
-      "Type" : "String",
-      "Default" : "m4.xlarge",
-      "AllowedValues" : [ "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge"],
-      "ConstraintDescription" : "must be a valid EC2 instance type."
-    },
-    "WindowsVersion" : {
-      "Description" : "The version of Windows to use",
-      "Type" : "String",
-      "Default" : "WS2012R2",
-      "AllowedValues" : ["WS2012R2"],
-      "ConstraintDescription" : "must be one of: WS2012R2"
-    },
-    "InstallationBucket" : {
-      "Description" : "The name of the S3 bucket from which to fetch installation files",
-      "Type" : "String",
-      "Default" : "tableau-server-installer",
-      "MinLength" : "1"
-    },
-    "RunasUser" : {
-      "Description" : "The name of the user which runs the Windows service; blank for default",
-      "Type" : "String"
-    },
-    "RunasPassword" : {
-      "Description" : "The password of the user which runs the Windows services; blank for default",
-      "Type" : "String",
+      "MinLength" : "1",
       "NoEcho" : "true"
     },
     "ContentAdminUser" : {
@@ -77,28 +33,31 @@
       "Default" : "admin",
       "MinLength" : "1"
     },
-    "ContentAdminPassword" : {
-      "Description" : "The password for the initial Admin user for Tableau server",
+    "InstanceType" : {
+      "Description" : "EC2 instance type for Tableau Server instances",
       "Type" : "String",
-      "MinLength" : "1",
-      "NoEcho" : "true"
+      "Default" : "m4.xlarge",
+      "AllowedValues" : [ "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge"],
+      "ConstraintDescription" : "must be a valid EC2 instance type."
     },
-    "TableauServerLicenseKey" : {
-      "Description" : "License Key",
+    "InstallationBucket" : {
+      "Description" : "The name of the S3 bucket from which to fetch installation files",
       "Type" : "String",
+      "Default" : "tableau-server-installer",
       "MinLength" : "1"
     },
-    "TableauServerPrimaryInstaller" : {
-      "Description" : "Primary installer to use; fetched from the Source S3 Bucket",
-      "Type" : "String",
-      "Default" : "Setup-Server-x64.exe",
-      "MinLength" : "1"
+    "KeyPairName" : {
+      "Description" : "Name of an existing EC2 KeyPair used to get the Administrator password for the instance",
+      "Type" : "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
     },
-    "TableauServerWorkerInstaller" : {
-      "Description" : "Worker installer to use; fetched from the Source S3 Bucket",
+    "LoadBalancerCidrForWeb" : {
+      "Description" : "CIDR for Web clients. This can be a specific subnet (yours), or open to the world. (e.g., 0.0.0.0/0)",
       "Type" : "String",
-      "Default" : "Setup-Worker-x64.exe",
-      "MinLength" : "1"
+      "MinLength" : "9",
+      "MaxLength" : "18",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
     },
     "RegFirstName" : {
       "Description" : "First Name",
@@ -150,6 +109,47 @@
     "RegCountry" : {
       "Description" : "Country",
       "Type" : "String"
+    },
+    "ResourceAvailabilityZone" : {
+        "Description" : "The availability zone (AZ) in which our server and storage volume reside",
+        "Type": "AWS::EC2::AvailabilityZone::Name"
+    },
+    "RunasPassword" : {
+      "Description" : "The password of the user which runs the Windows services; blank for default",
+      "Type" : "String",
+      "NoEcho" : "true"
+    },
+    "RunasUser" : {
+      "Description" : "The name of the user which runs the Windows service; blank for default",
+      "Type" : "String"
+    },
+    "SSLCertificateARN" : {
+        "Description" : "The Amazon Resource Name for the existing SSL cert you wish to use",
+        "Type" : "String"
+    },
+    "TableauServerLicenseKey" : {
+      "Description" : "License Key",
+      "Type" : "String",
+      "MinLength" : "1"
+    },
+    "TableauServerPrimaryInstaller" : {
+      "Description" : "Primary installer to use; fetched from the Source S3 Bucket",
+      "Type" : "String",
+      "Default" : "Setup-Server-x64.exe",
+      "MinLength" : "1"
+    },
+    "TableauServerWorkerInstaller" : {
+      "Description" : "Worker installer to use; fetched from the Source S3 Bucket",
+      "Type" : "String",
+      "Default" : "Setup-Worker-x64.exe",
+      "MinLength" : "1"
+    },
+    "WindowsVersion" : {
+      "Description" : "The version of Windows to use",
+      "Type" : "String",
+      "Default" : "WS2012R2",
+      "AllowedValues" : ["WS2012R2"],
+      "ConstraintDescription" : "must be one of: WS2012R2"
     }
   },
   "Metadata" : {
@@ -157,7 +157,7 @@
       "ParameterGroups" : [
         {
             "Label" : { "default" : "AWS Environment" },
-            "Parameters" : ["KeyName","ResourceAvailabilityZone","BastionCidrForRDP", "LoadBalancerCidrForWeb", "InstallationBucket"]
+            "Parameters" : ["KeyPairName","ResourceAvailabilityZone","BastionCidrForRDP", "LoadBalancerCidrForWeb", "InstallationBucket"]
         },
         {
             "Label" : { "default" : "Server DNS configuration"},
@@ -190,50 +190,26 @@
         "AwsPublicFQDN": {
             "default": "Full DNS name for cluster"
         },
-        "SSLCertificateARN": {
-            "default": "SSL certificate ARN"
-        },
-        "KeyName": {
-            "default": "EC2 keypair"
-        },
-        "ResourceAvailabilityZone": {
-            "default": "Target AZ"
-        },
         "BastionCidrForRDP": {
-            "default": "Source CIDR for RDP access to bastion host "
-        },
-        "LoadBalancerCidrForWeb": {
-            "default": "Source CIDR for web access to the web UI"
-        },
-        "InstanceType": {
-            "default": "EC2 Instance Type"
-        },
-        "WindowsVersion": {
-            "default": "Server OS Version"
-        },
-        "InstallationBucket": {
-            "default": "Source S3 Bucket"
-        },
-        "RunasUser": {
-            "default": "Service runas user"
-        },
-        "RunasPassword": {
-            "default": "Service runas password"
-        },
-        "ContentAdminUser": {
-            "default": "Portal admin username"
+            "default": "Allowed CIDR for RDP access to bastion host "
         },
         "ContentAdminPassword": {
             "default": "Portal admin password"
         },
-        "TableauServerLicenseKey": {
-            "default": "Tableau Activation Key"
+        "ContentAdminUser": {
+            "default": "Portal admin username"
         },
-        "TableauServerPrimaryInstaller": {
-            "default": "Primary installer executable"
+        "InstanceType": {
+            "default": "Tableau Server EC2 Instance Type"
         },
-        "TableauServerWorkerInstaller": {
-            "default": "Worker installer executable"
+        "InstallationBucket": {
+            "default": "Source S3 Bucket"
+        },
+        "KeyPairName": {
+            "default": "Key Pair Name"
+        },
+        "LoadBalancerCidrForWeb": {
+            "default": "Allowed CIDR for access to the Web UI"
         },
         "RegFirstName": {
             "default": "First Name"
@@ -270,6 +246,30 @@
         },
         "RegCountry": {
             "default": "Country"
+        },
+        "ResourceAvailabilityZone": {
+            "default": "Target AZ"
+        },
+        "RunasPassword": {
+            "default": "Service runas password"
+        },
+        "RunasUser": {
+            "default": "Service runas user"
+        },
+        "SSLCertificateARN": {
+            "default": "SSL certificate ARN (Requires mattching DNS name)"
+        },
+        "TableauServerLicenseKey": {
+            "default": "Tableau Activation Key"
+        },
+        "TableauServerPrimaryInstaller": {
+            "default": "Primary installer executable"
+        },
+        "TableauServerWorkerInstaller": {
+            "default": "Worker installer executable"
+        },
+        "WindowsVersion": {
+            "default": "Server OS Version"
         }
       }
     }
@@ -597,7 +597,7 @@
         "ImageId" : { "Fn::FindInMap" : [ "AWSAMIRegionMap", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
         "AvailabilityZone" : { "Ref" : "ResourceAvailabilityZone" },
         "SecurityGroupIds" : [ {"Ref" : "BastionSecurityGroup"} ],
-        "KeyName" : { "Ref" : "KeyName" },
+        "KeyName" : { "Ref" : "KeyPairName" },
         "SubnetId" : { "Ref" : "ClusterPublicSubnet"},
         "Tags": [
             {
@@ -771,7 +771,7 @@
             "AvailabilityZone" : { "Ref" : "ResourceAvailabilityZone" },
             "SecurityGroupIds" : [ {"Ref" : "InternalSecurityGroup"} ],
             "IamInstanceProfile" : { "Ref" : "TableauWindowsServerInstanceProfile" },
-            "KeyName" : { "Ref" : "KeyName" },
+            "KeyName" : { "Ref" : "KeyPairName" },
             "SubnetId" : { "Ref" : "ClusterPrivateSubnet"},
             "PrivateIpAddress" : "10.0.1.11",
             "BlockDeviceMappings" : [
@@ -841,7 +841,7 @@
             "AvailabilityZone" : { "Ref" : "ResourceAvailabilityZone" },
             "SecurityGroupIds" : [ {"Ref" : "InternalSecurityGroup"} ],
             "IamInstanceProfile" : { "Ref" : "TableauWindowsServerInstanceProfile" },
-            "KeyName" : { "Ref" : "KeyName" },
+            "KeyName" : { "Ref" : "KeyPairName" },
             "SubnetId" : { "Ref" : "ClusterPrivateSubnet"},
             "PrivateIpAddress" : "10.0.1.12",
             "BlockDeviceMappings" : [
@@ -911,7 +911,7 @@
             "AvailabilityZone" : { "Ref" : "ResourceAvailabilityZone" },
             "SecurityGroupIds" : [ {"Ref" : "InternalSecurityGroup"} ],
             "IamInstanceProfile" : { "Ref" : "TableauWindowsServerInstanceProfile" },
-            "KeyName" : { "Ref" : "KeyName" },
+            "KeyName" : { "Ref" : "KeyPairName" },
             "SubnetId" : { "Ref" : "ClusterPrivateSubnet"},
             "PrivateIpAddress" : "10.0.1.13",
             "BlockDeviceMappings" : [

--- a/CloudFormation/public-sample-ssl-cluster.cfn
+++ b/CloudFormation/public-sample-ssl-cluster.cfn
@@ -36,8 +36,8 @@
     "InstanceType" : {
       "Description" : "EC2 instance type for Tableau Server instances",
       "Type" : "String",
-      "Default" : "m4.xlarge",
-      "AllowedValues" : [ "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge"],
+      "Default" : "m4.4xlarge",
+      "AllowedValues" : [ "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.8xlarge", "r4.xlarge", "r4.2xlarge", "r4.4xlarge", "r4.8xlarge"],
       "ConstraintDescription" : "must be a valid EC2 instance type."
     },
     "InstallationBucket" : {
@@ -129,6 +129,12 @@
       "Default" : "Setup-Server-x64.exe",
       "MinLength" : "1"
     },
+    "TableauServerVolumeSize" : {
+      "Description" : "Size of volume for server in GB; need at least 30 GB free for server installation",
+      "Type" : "Number",
+      "Default" : "100",
+      "MinValue" : "30"
+    },
     "TableauServerWorkerInstaller" : {
       "Description" : "Worker installer to use; fetched from the Source S3 Bucket",
       "Type" : "String",
@@ -156,7 +162,7 @@
         },
         {
             "Label" : { "default" : "Machine Configuration" },
-            "Parameters" : ["InstanceType", "WindowsVersion"]
+            "Parameters" : ["InstanceType", "TableauServerVolumeSize", "WindowsVersion"]
         },
         {
             "Label" : { "default" : "Installation Config" },
@@ -249,6 +255,9 @@
         },
         "TableauServerPrimaryInstaller": {
             "default": "Primary installer executable"
+        },
+        "TableauServerVolumeSize": {
+            "default": "Size for server volume in GB; Requires at least 30 GB"
         },
         "TableauServerWorkerInstaller": {
             "default": "Worker installer executable"
@@ -496,10 +505,14 @@
     },
     "ServerLoadBalancer" : {
         "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
-        "DependsOn" : ["LoadBalancerSecurityGroup", "PrimaryHost"],
+        "DependsOn" : ["LoadBalancerSecurityGroup", "PrimaryHost", "WorkerHost1", "WorkerHost2" ],
         "Properties" : {
             "Scheme" : "internet-facing",
-            "Instances" : [ { "Ref" : "PrimaryHost"} ],
+            "Instances" : [ 
+                { "Ref" : "PrimaryHost"},
+                { "Ref" : "WorkerHost1"},
+                { "Ref" : "WorkerHost2"}
+            ],
             "Subnets" : [  { "Ref" : "ClusterPublicSubnet"} ],
             "SecurityGroups" : [ { "Ref" : "LoadBalancerSecurityGroup"} ],
             "Listeners" : [
@@ -717,11 +730,9 @@
                         "5-run-installer" : {
                             "cwd" : "c:\\tabsetup",
                             "command" : { "Fn::Join" : [ " ", [
-                                "set \"TA_READ_FILE_CHUNK_SIZE=1500\" && ",
                                 "c:\\Python27\\python.exe",
                                 "ScriptedInstaller.py", "install",
                                 "--installerLog", "C:\\tabsetup\\tabinstall.txt",
-                                "--installDir C:\\TableauServer",
                                 "--secretsFile c:\\tabsetup\\secrets.json",
                                 "--configFile c:\\tabsetup\\config.yml",
                                 "--registrationFile c:\\tabsetup\\registration.json",
@@ -760,7 +771,7 @@
             "BlockDeviceMappings" : [
                { 
                 "DeviceName" : "/dev/sda1",
-                "Ebs" : { "VolumeSize" : "100" }
+                "Ebs" : { "VolumeSize" : { "Ref" : "TableauServerVolumeSize" } }
                }
             ],
             "UserData" : { "Fn::Base64" : { "Fn::Join" : ["\n", [
@@ -801,7 +812,7 @@
                       "2-run-installer" : {
                         "cwd" : "c:\\tabsetup",
                         "command" : { "Fn::Join" : [ " ", [
-                          "c:\\tabsetup\\tableau-worker-installer.exe /PRIMARYIP=\"10.0.1.11\" /DIR=C:\\TableauServer /VERYSILENT /SUPPRESSMSGBOXES /ACCEPTEULA /LOG=c:\\tabsetup\\installerlog.txt",
+                          "c:\\tabsetup\\tableau-worker-installer.exe /PRIMARYIP=\"10.0.1.11\" /VERYSILENT /SUPPRESSMSGBOXES /ACCEPTEULA /LOG=c:\\tabsetup\\installerlog.txt",
                           " > c:\\tabsetup\\installer-output.txt 2>&1"
                           ]]
                         },
@@ -830,7 +841,7 @@
             "BlockDeviceMappings" : [
                { 
                 "DeviceName" : "/dev/sda1",
-                "Ebs" : { "VolumeSize" : "100" }
+                "Ebs" : { "VolumeSize" : { "Ref" : "TableauServerVolumeSize" } }
                }
             ],
             "UserData" : { "Fn::Base64" : { "Fn::Join" : ["\n", [
@@ -871,7 +882,7 @@
                       "2-run-installer" : {
                         "cwd" : "c:\\tabsetup",
                         "command" : { "Fn::Join" : [ " ", [
-                          "c:\\tabsetup\\tableau-worker-installer.exe /DIR=C:\\TableauServer /PRIMARYIP=\"10.0.1.11\" /VERYSILENT /SUPPRESSMSGBOXES /ACCEPTEULA /LOG=c:\\tabsetup\\installerlog.txt",
+                          "c:\\tabsetup\\tableau-worker-installer.exe /PRIMARYIP=\"10.0.1.11\" /VERYSILENT /SUPPRESSMSGBOXES /ACCEPTEULA /LOG=c:\\tabsetup\\installerlog.txt",
                           " > c:\\tabsetup\\installer-output.txt 2>&1"
                           ]]
                         },
@@ -900,7 +911,7 @@
             "BlockDeviceMappings" : [
                { 
                 "DeviceName" : "/dev/sda1",
-                "Ebs" : { "VolumeSize" : "100" }
+                "Ebs" : { "VolumeSize" : { "Ref" : "TableauServerVolumeSize" } }
                }
             ],
             "UserData" : { "Fn::Base64" : { "Fn::Join" : ["\n", [
@@ -945,9 +956,9 @@
     }
   },
   "Outputs" : {
-    "BastionIpAddress" : {
-        "Description" : "Public IP Address of bastion host",
-        "Value" : { "Fn::GetAtt" : [ "BastionHost", "PublicIp"]}
+    "VPCId" : {
+        "Description" : "VPC created for cluster",
+        "Value" : {  "Ref" : "ClusterVPC" },
     },
     "BastionDNSName" : {
         "Description" : "Public DNS name of bastion host",

--- a/CloudFormation/public-sample-ssl-cluster.cfn
+++ b/CloudFormation/public-sample-ssl-cluster.cfn
@@ -59,6 +59,7 @@
     "InstallationBucket" : {
       "Description" : "The name of the S3 bucket from which to fetch installation files",
       "Type" : "String",
+      "Default" : "tableau-server-installer",
       "MinLength" : "1"
     },
     "RunasUser" : {

--- a/CloudFormation/public-sample-ssl-cluster.cfn
+++ b/CloudFormation/public-sample-ssl-cluster.cfn
@@ -15,8 +15,7 @@
     },
     "SSLCertificateARN" : {
         "Description" : "The Amazon Resource Name for the existing SSL cert you wish to use",
-        "Type" : "String",
-        "Default" : ""
+        "Type" : "String"
     },
     "KeyName" : {
       "Description" : "Name of an existing EC2 KeyPair used to get the Administrator password for the instance",
@@ -32,7 +31,6 @@
       "Type" : "String",
       "MinLength" : "9",
       "MaxLength" : "18",
-      "Default": "1.1.1.1/32",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
     },
@@ -41,7 +39,6 @@
       "Type" : "String",
       "MinLength" : "9",
       "MaxLength" : "18",
-      "Default": "1.1.1.1/32",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
     },
@@ -55,9 +52,9 @@
     "WindowsVersion" : {
       "Description" : "The version of Windows to use",
       "Type" : "String",
-      "Default" : "Windows2012r2",
-      "AllowedValues" : ["Windows2012r2"],
-      "ConstraintDescription" : "must be one of: Windows2012r2"
+      "Default" : "WS2012R2",
+      "AllowedValues" : ["WS2012R2"],
+      "ConstraintDescription" : "must be one of: WS2012R2"
     },
     "InstallationBucket" : {
       "Description" : "The name of the S3 bucket from which to fetch installation files",
@@ -66,13 +63,11 @@
     },
     "RunasUser" : {
       "Description" : "The name of the user which runs the Windows service; blank for default",
-      "Type" : "String",
-      "Default" : ""
+      "Type" : "String"
     },
     "RunasPassword" : {
       "Description" : "The password of the user which runs the Windows services; blank for default",
       "Type" : "String",
-      "Default" : "",
       "NoEcho" : "true"
     },
     "ContentAdminUser" : {
@@ -279,11 +274,53 @@
     }
   },
   "Mappings" : {
-    "AWSRegion2AMI" : {
-      "us-east-1"        : { "Windows2012r2" : "ami-ee7805f9"},
-      "us-west-2"        : { "Windows2012r2" : "ami-2827f548"},
-      "us-west-1"        : { "Windows2012r2" : "ami-c06b24a0"}
-    }
+        "AWSAMIRegionMap": {
+            "AMI": {
+                "WS2012R2": "Windows_Server-2012-R2_RTM-English-64Bit-Base-2016.11.23"
+            },
+            "ap-northeast-1": {
+                "WS2012R2": "ami-5b299d3a"
+            },
+            "ap-northeast-2": {
+                "WS2012R2": "ami-69d30407"
+            },
+            "ap-south-1": {
+                "WS2012R2": "ami-79255216"
+            },
+            "ap-southeast-1": {
+                "WS2012R2": "ami-9d7ad8fe"
+            },
+            "ap-southeast-2": {
+                "WS2012R2": "ami-9fe7d9fc"
+            },
+            "ca-central-1": {
+                "WS2012R2": "ami-f57fcd91"
+            },
+            "eu-central-1": {
+                "WS2012R2": "ami-21cb0f4e"
+            },
+            "eu-west-1": {
+                "WS2012R2": "ami-95d984e6"
+            },
+            "eu-west-2": {
+                "WS2012R2": "ami-bb353fdf"
+            },
+            "sa-east-1": {
+                "WS2012R2": "ami-628e100e"
+            },
+            "us-east-1": {
+                "WS2012R2": "ami-bfeddca8"
+            },
+            "us-east-2": {
+                "WS2012R2": "ami-e999c38c"
+            },
+            "us-west-1": {
+                "WS2012R2": "ami-8b590deb"
+            },
+            "us-west-2": {
+                "WS2012R2": "ami-24e64944"
+            }
+        }
   },
   "Conditions" : {
   },
@@ -556,7 +593,7 @@
       "DependsOn" : ["BastionSecurityGroup"],
       "Properties": {
         "InstanceType" : "t2.micro",
-        "ImageId" : { "Fn::FindInMap" : [ "AWSRegion2AMI", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
+        "ImageId" : { "Fn::FindInMap" : [ "AWSAMIRegionMap", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
         "AvailabilityZone" : { "Ref" : "ResourceAvailabilityZone" },
         "SecurityGroupIds" : [ {"Ref" : "BastionSecurityGroup"} ],
         "KeyName" : { "Ref" : "KeyName" },
@@ -665,7 +702,7 @@
                                 "worker2.dataserver.procs" : "INTEGER:1",
                                 "worker2.dataengine.procs" : "INTEGER:1",
                                 "worker2.filestore.enabled" : "true",
-                                "worker2.zookeeper.procs" : "INTEGER:1",
+                                "worker2.zookeeper.procs" : "INTEGER:1"
                             }
                         },
                         "c:\\tabsetup\\tableau-primary-installer.exe" : {
@@ -729,7 +766,7 @@
         },
         "Properties": {
             "InstanceType" : { "Ref" : "InstanceType" },
-            "ImageId" : { "Fn::FindInMap" : [ "AWSRegion2AMI", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
+            "ImageId" : { "Fn::FindInMap" : [ "AWSAMIRegionMap", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
             "AvailabilityZone" : { "Ref" : "ResourceAvailabilityZone" },
             "SecurityGroupIds" : [ {"Ref" : "InternalSecurityGroup"} ],
             "IamInstanceProfile" : { "Ref" : "TableauWindowsServerInstanceProfile" },
@@ -799,7 +836,7 @@
         },
         "Properties": {
             "InstanceType" : { "Ref" : "InstanceType" },
-            "ImageId" : { "Fn::FindInMap" : [ "AWSRegion2AMI", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
+            "ImageId" : { "Fn::FindInMap" : [ "AWSAMIRegionMap", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
             "AvailabilityZone" : { "Ref" : "ResourceAvailabilityZone" },
             "SecurityGroupIds" : [ {"Ref" : "InternalSecurityGroup"} ],
             "IamInstanceProfile" : { "Ref" : "TableauWindowsServerInstanceProfile" },
@@ -869,7 +906,7 @@
         },
         "Properties": {
             "InstanceType" : { "Ref" : "InstanceType" },
-            "ImageId" : { "Fn::FindInMap" : [ "AWSRegion2AMI", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
+            "ImageId" : { "Fn::FindInMap" : [ "AWSAMIRegionMap", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
             "AvailabilityZone" : { "Ref" : "ResourceAvailabilityZone" },
             "SecurityGroupIds" : [ {"Ref" : "InternalSecurityGroup"} ],
             "IamInstanceProfile" : { "Ref" : "TableauWindowsServerInstanceProfile" },

--- a/CloudFormation/public-sample-ssl-single-server.cfn
+++ b/CloudFormation/public-sample-ssl-single-server.cfn
@@ -14,9 +14,8 @@
         "MinLength" : "1"
     },
     "SSLCertificateARN" : {
-        "Description" : "The ARN for the SSL cert use; blank for no SSL",
-        "Type" : "String",
-        "Default" : ""
+        "Description" : "The ARN for the SSL cert use",
+        "Type" : "String"
     },
     "KeyName" : {
       "Description" : "Name of an existing EC2 KeyPair used to get the Administrator password for the instance",
@@ -32,7 +31,6 @@
       "Type" : "String",
       "MinLength" : "9",
       "MaxLength" : "18",
-      "Default": "0.0.0.0/0",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
     },
@@ -41,7 +39,6 @@
       "Type" : "String",
       "MinLength" : "9",
       "MaxLength" : "18",
-      "Default": "0.0.0.0/0",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
     },
@@ -59,7 +56,7 @@
       "ConstraintDescription" : "must be a valid EC2 instance type."
     },
     "TableauServerVolumeSize" : {
-      "Description" : "Size of volume for server in GB; need at least 30 meg free for server installation",
+      "Description" : "Size of volume for server in GB; need at least 30 GB free for server installation",
       "Type" : "Number",
       "Default" : "100",
       "MinValue" : "60"
@@ -67,19 +64,17 @@
     "WindowsVersion" : {
       "Description" : "The version of Windows to use",
       "Type" : "String",
-      "Default" : "Windows2012r2",
-      "AllowedValues" : [ "Windows2012r2"],
-      "ConstraintDescription" : "must be one : Windows2012r2"
+      "Default" : "WS2012R2",
+      "AllowedValues" : [ "WS2012R2"],
+      "ConstraintDescription" : "must be one : WS2012R2"
     },
     "RunasUser" : {
       "Description" : "The name of the user which runs the service; blank for default",
-      "Type" : "String",
-      "Default" : ""
+      "Type" : "String"
     },
     "RunasPassword" : {
       "Description" : "The password of the user which runs the service; blank for default",
       "Type" : "String",
-      "Default" : "",
       "NoEcho" : "true"
     },
     "ContentAdminUser" : {
@@ -247,10 +242,52 @@
     }
   },
   "Mappings" : {
-    "AWSRegion2AMI" : {
-      "us-east-1"        : { "Windows2012r2" : "ami-ee7805f9"},
-      "us-west-2"        : { "Windows2012r2" : "ami-2827f548"},
-      "us-west-1"        : { "Windows2012r2" : "ami-c06b24a0"}
+    "AWSAMIRegionMap": {
+        "AMI": {
+            "WS2012R2": "Windows_Server-2012-R2_RTM-English-64Bit-Base-2016.11.23"
+        },
+        "ap-northeast-1": {
+            "WS2012R2": "ami-5b299d3a"
+        },
+        "ap-northeast-2": {
+            "WS2012R2": "ami-69d30407"
+        },
+        "ap-south-1": {
+            "WS2012R2": "ami-79255216"
+        },
+        "ap-southeast-1": {
+            "WS2012R2": "ami-9d7ad8fe"
+        },
+        "ap-southeast-2": {
+            "WS2012R2": "ami-9fe7d9fc"
+        },
+        "ca-central-1": {
+            "WS2012R2": "ami-f57fcd91"
+        },
+        "eu-central-1": {
+            "WS2012R2": "ami-21cb0f4e"
+        },
+        "eu-west-1": {
+            "WS2012R2": "ami-95d984e6"
+        },
+        "eu-west-2": {
+            "WS2012R2": "ami-bb353fdf"
+        },
+        "sa-east-1": {
+            "WS2012R2": "ami-628e100e"
+        },
+        "us-east-1": {
+            "WS2012R2": "ami-bfeddca8"
+        },
+        "us-east-2": {
+            "WS2012R2": "ami-e999c38c"
+        },
+        "us-west-1": {
+            "WS2012R2": "ami-8b590deb"
+        },
+        "us-west-2": {
+            "WS2012R2": "ami-24e64944"
+        }
     }
   },
   "Conditions" : {
@@ -319,11 +356,6 @@
                               "Effect": "Allow",
                               "Action": ["s3:GetObject"],
                               "Resource": {"Fn::Sub" : "arn:aws:s3:::${InstallationBucket}/*"}
-                            },
-                            {
-                              "Effect": "Allow",
-                              "Action": [ "s3:ListBucket"],
-                              "Resource": {"Fn::Sub" : "arn:aws:s3:::${InstallationBucket}"}
                             }
                           ]
                     }
@@ -461,7 +493,7 @@
       },
       "Properties": {
         "InstanceType" : { "Ref" : "InstanceType" },
-        "ImageId" : { "Fn::FindInMap" : [ "AWSRegion2AMI", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
+        "ImageId" : { "Fn::FindInMap" : [ "AWSAMIRegionMap", { "Ref" : "AWS::Region" }, { "Ref" : "WindowsVersion" } ]},
         "AvailabilityZone" : { "Ref" : "ResourceAvailabilityZone" },
         "BlockDeviceMappings" : [
            {

--- a/CloudFormation/public-sample-ssl-single-server.cfn
+++ b/CloudFormation/public-sample-ssl-single-server.cfn
@@ -305,7 +305,7 @@
             "default": "Server installer executable"
         },
         "TableauServerLicenseKey": {
-            "default": "License Key (leave blank for trial)",
+            "default": "License Key (leave blank for trial)"
         },
         "TableauServerVolumeSize": {
             "default": "Size for server volume in GB"
@@ -387,9 +387,8 @@
     }
   },
   "Conditions" : {
-    "EnablePublicFirewallRule" : { "Fn::Equals" : [{ "Ref" : "PublicFirewallProfileHole"}, "Yes"]},
-    "IsTrial" :                  { "Fn::Equals":  [ "", { "Ref" : "TableauServerLicenseKey"}]
-    }
+      "EnablePublicFirewallRule" : { "Fn::Equals" : [{ "Ref" : "PublicFirewallProfileHole"}, "Yes"]},
+      "IsTrial" :                  { "Fn::Equals":  [ "", { "Ref" : "TableauServerLicenseKey"}]}
   },
   "Resources" : {
     "InstanceSecurityGroup" : {
@@ -668,11 +667,7 @@
         "Description" : "EC2 InstanceID of the instance running Tableau Server",
         "Value" : { "Ref" : "TableauWindowsServer" }
     },
-    "LoadBalancerId" : {
-        "Description" : "Logical ID of the load balancer used ",
-        "Value" : { "Ref" : "TableauWindowsServer" }
-    },
-    "InstanceDNSName" : {
+    "PublicDNSName" : {
         "Description" : "Public DNS name of instance running Tableau Server; use for RDS connections",
         "Value" : { "Fn::GetAtt" : [ "TableauWindowsServer", "PublicDnsName"]}
     },

--- a/CloudFormation/public-sample-ssl-single-server.cfn
+++ b/CloudFormation/public-sample-ssl-single-server.cfn
@@ -13,34 +13,17 @@
         "Type" : "String",
         "MinLength" : "1"
     },
-    "SSLCertificateARN" : {
-        "Description" : "The ARN for the SSL cert use",
-        "Type" : "String"
-    },
-    "KeyName" : {
-      "Description" : "Name of an existing EC2 KeyPair used to get the Administrator password for the instance",
-      "Type" : "AWS::EC2::KeyPair::KeyName",
-      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
-    },
-    "ResourceAvailabilityZone" : {
-        "Description" : "The availability zone in which our server and storage volume reside",
-        "Type": "AWS::EC2::AvailabilityZone::Name"
-    },
-    "SourceCidrForRDP" : {
-      "Description" : "IP Cidr from which you are likely to RDP into the instances. You can add rules later by modifying the created security groups e.g. 54.32.98.160/32",
+    "ContentAdminPassword" : {
+      "Description" : "The password for the initial Admin user for Tableau server",
       "Type" : "String",
-      "MinLength" : "9",
-      "MaxLength" : "18",
-      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
+      "MinLength" : "1",
+      "NoEcho" : "true"
     },
-    "SourceCidrForWeb" : {
-      "Description" : "IP Cidr for Web clients. This can be a specific subnet (yours), or open to the world. 0.0.0.0/0",
+    "ContentAdminUser" : {
+      "Description" : "The name of the initial Admin user for Tableau server",
       "Type" : "String",
-      "MinLength" : "9",
-      "MaxLength" : "18",
-      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
+      "Default" : "admin",
+      "MinLength" : "1"
     },
     "InstallationBucket" : {
       "Description" : "The name of the S3 bucket from which to fetch the server installer",
@@ -55,44 +38,17 @@
       "AllowedValues" : [ "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge"],
       "ConstraintDescription" : "must be a valid EC2 instance type."
     },
-    "TableauServerVolumeSize" : {
-      "Description" : "Size of volume for server in GB; need at least 30 GB free for server installation",
-      "Type" : "Number",
-      "Default" : "100",
-      "MinValue" : "60"
+    "KeyPairName" : {
+      "Description" : "Name of an existing EC2 KeyPair used to get the Administrator password for the instance",
+      "Type" : "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
     },
-    "WindowsVersion" : {
-      "Description" : "The version of Windows to use",
+    "PublicFirewallProfileHole": {
+      "Description" : "If firewall rules are created allowing access to the server, create rule allowing access via the Public profile (useful for AWS)",
       "Type" : "String",
-      "Default" : "WS2012R2",
-      "AllowedValues" : [ "WS2012R2"],
-      "ConstraintDescription" : "must be one : WS2012R2"
-    },
-    "RunasUser" : {
-      "Description" : "The name of the user which runs the service; blank for default",
-      "Type" : "String"
-    },
-    "RunasPassword" : {
-      "Description" : "The password of the user which runs the service; blank for default",
-      "Type" : "String",
-      "NoEcho" : "true"
-    },
-    "ContentAdminUser" : {
-      "Description" : "The name of the initial Admin user for Tableau server",
-      "Type" : "String",
-      "Default" : "admin",
-      "MinLength" : "1"
-    },
-    "ContentAdminPassword" : {
-      "Description" : "The password for the initial Admin user for Tableau server",
-      "Type" : "String",
-      "MinLength" : "1",
-      "NoEcho" : "true"
-    },
-    "TableauServerLicenseKey" : {
-      "Description" : "License Key",
-      "Type" : "String",
-      "MinLength" : "1"
+      "Default" : "Yes",
+      "AllowedValues" : ["Yes", "No"],
+      "ConstraintDescription" : "must be one of Yes , No"
     },
     "RegFirstName" : {
       "Description" : "First Name",
@@ -145,18 +101,62 @@
       "Description" : "Country",
       "Type" : "String"
     },
+    "ResourceAvailabilityZone" : {
+        "Description" : "The availability zone in which our server and storage volume reside",
+        "Type": "AWS::EC2::AvailabilityZone::Name"
+    },
+    "RunasPassword" : {
+      "Description" : "The password of the user which runs the service; blank for default",
+      "Type" : "String",
+      "NoEcho" : "true"
+    },
+    "RunasUser" : {
+      "Description" : "The name of the user which runs the service; blank for default",
+      "Type" : "String"
+    },
+    "SourceCidrForRDP" : {
+      "Description" : "IP Cidr from which you are likely to RDP into the instances. You can add rules later by modifying the created security groups e.g. 54.32.98.160/32",
+      "Type" : "String",
+      "MinLength" : "9",
+      "MaxLength" : "18",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
+    },
+    "SourceCidrForWeb" : {
+      "Description" : "IP Cidr for Web clients. This can be a specific subnet (yours), or open to the world. 0.0.0.0/0",
+      "Type" : "String",
+      "MinLength" : "9",
+      "MaxLength" : "18",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
+    },
+    "SSLCertificateARN" : {
+        "Description" : "The ARN for the SSL cert use",
+        "Type" : "String"
+    },
     "TableauServerInstaller" : {
       "Description" : "Installer to use",
       "Type" : "String",
       "Default" : "Setup-Server-x64.exe",
       "MinLength" : "1"
     },
-    "PublicFirewallProfileHole": {
-      "Description" : "If firewall rules are created allowing access to the server, create rule allowing access via the Public profile (useful for AWS)",
+    "TableauServerLicenseKey" : {
+      "Description" : "License Key",
       "Type" : "String",
-      "Default" : "No",
-      "AllowedValues" : ["Yes", "No"],
-      "ConstraintDescription" : "must be one of Yes , No"
+      "MinLength" : "1"
+    },
+    "TableauServerVolumeSize" : {
+      "Description" : "Size of volume for server in GB; need at least 30 GB free for server installation",
+      "Type" : "Number",
+      "Default" : "100",
+      "MinValue" : "60"
+    },
+    "WindowsVersion" : {
+      "Description" : "The version of Windows to use",
+      "Type" : "String",
+      "Default" : "WS2012R2",
+      "AllowedValues" : [ "WS2012R2"],
+      "ConstraintDescription" : "must be one : WS2012R2"
     },
     "Worker0GatewayPort" : {
       "Description" : "Web port for Tableau gateway",
@@ -211,7 +211,7 @@
         },
         {
             "Label" : { "default" : "AWS Environment" },
-            "Parameters" : ["KeyName","ResourceAvailabilityZone","SourceCidrForRDP","SourceCidrForWeb", "InstallationBucket"]
+            "Parameters" : ["KeyPairName","ResourceAvailabilityZone","SourceCidrForRDP","SourceCidrForWeb", "InstallationBucket"]
         },
         {
             "Label" : { "default" : "Machine Configuration" },
@@ -238,7 +238,119 @@
             "Parameters" : [ "TableauServerInstaller" ]
         }
       ],
-      "ParameterLabels" : {}
+      "ParameterLabels" : {
+        "AwsHostedZoneId": {
+            "default": "DNS ZoneID"
+        },
+        "AwsPublicFQDN": {
+            "default": "Full DNS name for cluster"
+        },
+        "ContentAdminPassword": {
+            "default": "Portal admin password"
+        },
+        "ContentAdminUser": {
+            "default": "Portal admin username"
+        },
+        "InstallationBucket": {
+            "default": "Source S3 Bucket"
+        },
+        "InstanceType": {
+            "default": "Tableau Server EC2 Instance Type"
+        },
+        "KeyPairName": {
+            "default": "Key Pair Name"
+        },
+        "PublicFirewallProfileHole": {
+            "default": "Windows firewall rules also apply to the Public profile"
+        },
+        "RegFirstName": {
+            "default": "First Name"
+        },
+        "RegLastName": {
+            "default": "Last name"
+        },
+        "RegEmail": {
+            "default": "Email Address"
+        },
+        "RegCompany": {
+            "default": "Company"
+        },
+        "RegTitle": {
+            "default": "Title"
+        },
+        "RegDepartment": {
+            "default": "Department"
+        },
+        "RegIndustry": {
+            "default": "Industry"
+        },
+        "RegPhone": {
+            "default": "Phone"
+        },
+        "RegCity": {
+            "default": "City"
+        },
+        "RegState": {
+            "default": "State"
+        },
+        "RegZip": {
+            "default": "Zip/Postal Code"
+        },
+        "RegCountry": {
+            "default": "Country"
+        },
+        "ResourceAvailabilityZone": {
+            "default": "Target AZ"
+        },
+        "RunasPassword": {
+            "default": "Service runas password"
+        },
+        "RunasUser": {
+            "default": "Service runas user"
+        },
+        "SourceCidrForRDP": {
+            "default": "Allowed CIDR for RDP access"
+        },
+        "SourceCidrForWeb": {
+            "default": "Allowed CIDR for access to the Web UI"
+        },
+        "SSLCertificateARN": {
+            "default": "SSL certificate ARN (Requires mattching DNS name)"
+        },
+        "TableauServerInstaller": {
+            "default": "Server installer executable"
+        },
+        "TableauServerLicenseKey": {
+            "default": "Tableau Activation Key"
+        },
+        "TableauServerVolumeSize": {
+            "default": "Size for server volume in GB; Requires at least 30 GB"
+        },
+        "WindowsVersion": {
+            "default": "Server OS Version"
+        },
+        "Worker0GatewayPort": {
+            "default": "Gateway (web) port"
+        },
+        "Worker0BackgrounderProcs": {
+            "default": "Number of Backgrounder processes"
+        },
+        "Worker0CacheserverProcs": {
+            "default": "Number of CacheServer processes"
+        },
+        "Worker0DataengineProcs": {
+            "default": "Numnber of Data Engine processes"
+        },
+        "Worker0DataserverProcs": {
+            "default": "Numnber of Data Server processes"
+        },
+        "Worker0VizportalProcs": {
+            "default": "Number of Vizportal processes"
+        },
+        "Worker0VizqlserverProcs": {
+            "default": "Number of VizqlServer processes"
+        }
+      }
     }
   },
   "Mappings" : {
@@ -503,7 +615,7 @@
         ],
         "SecurityGroups" : [ {"Ref" : "InstanceSecurityGroup"} ],
         "IamInstanceProfile" : { "Ref" : "TableauWindowsServerInstanceProfile" },
-        "KeyName" : { "Ref" : "KeyName" },
+        "KeyName" : { "Ref" : "KeyPairName" },
         "UserData" : { "Fn::Base64" : { "Fn::Join" : ["", [
             "<script>\n",
             { "Fn::Sub" : "cfn-init.exe -v -s ${AWS::StackId} -r TableauWindowsServer --region ${AWS::Region}\n"},

--- a/CloudFormation/public-sample-ssl-single-server.cfn
+++ b/CloudFormation/public-sample-ssl-single-server.cfn
@@ -34,8 +34,8 @@
     "InstanceType" : {
       "Description" : "Amazon EC2 instance type",
       "Type" : "String",
-      "Default" : "m4.xlarge",
-      "AllowedValues" : [ "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge"],
+      "Default" : "m4.4xlarge",
+      "AllowedValues" : [ "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.8xlarge", "r4.xlarge", "r4.2xlarge", "r4.4xlarge", "r4.8xlarge"],
       "ConstraintDescription" : "must be a valid EC2 instance type."
     },
     "KeyPairName" : {
@@ -140,7 +140,7 @@
       "Description" : "Size of volume for server in GB; need at least 30 GB free for server installation",
       "Type" : "Number",
       "Default" : "100",
-      "MinValue" : "60"
+      "MinValue" : "30"
     },
     "WindowsVersion" : {
       "Description" : "The version of Windows to use",
@@ -306,7 +306,7 @@
             "default": "Server installer executable"
         },
         "TableauServerLicenseKey": {
-            "default": "Tableau Activation Key"
+            "Description": "License Key (leave blank for trial)",
         },
         "TableauServerVolumeSize": {
             "default": "Size for server volume in GB; Requires at least 30 GB"
@@ -388,7 +388,9 @@
     }
   },
   "Conditions" : {
-    "EnablePublicFirewallRule" : { "Fn::Equals" : [ {"Ref" : "PublicFirewallProfileHole"}, "Yes"]}
+    "EnablePublicFirewallRule" : { "Fn::Equals" : [{ "Ref" : "PublicFirewallProfileHole"}, "Yes"]},
+    "IsTrial" :                  { "Fn::Equals":  [{ "Ref" : "TableauServerLicenseKey", "" }]
+    }
   },
   "Resources" : {
     "InstanceSecurityGroup" : {
@@ -559,12 +561,19 @@
                   "c:\\Python27\\python.exe",
                   "ScriptedInstaller.py", "install",
                   "--installerLog", "C:\\tabsetup\\tabinstall.txt",
-                  "--installDir C:\\TableauServer",
                   { "Fn::If" : [ "EnablePublicFirewallRule", "--enablePublicFwRule", ""]},
                   "--secretsFile c:\\tabsetup\\secrets.json",
                   "--configFile c:\\tabsetup\\config.yml",
                   "--registrationFile c:\\tabsetup\\registration.json",
-                  "--licenseKey", { "Ref" : "TableauServerLicenseKey"},
+                  {
+                    "Fn::If": [
+                        "IsTrial",
+                        "--trialLicense",
+                        {
+                            "Fn::Sub": "--licenseKey ${TableauServerLicenseKey}"
+                        }
+                    ]
+                  },
                   "c:\\tabsetup\\tableau-server-installer.exe"
                   ]]
                 },

--- a/CloudFormation/public-sample-ssl-single-server.cfn
+++ b/CloudFormation/public-sample-ssl-single-server.cfn
@@ -306,10 +306,10 @@
             "default": "Server installer executable"
         },
         "TableauServerLicenseKey": {
-            "Description": "License Key (leave blank for trial)",
+            "default": "License Key (leave blank for trial)",
         },
         "TableauServerVolumeSize": {
-            "default": "Size for server volume in GB; Requires at least 30 GB"
+            "default": "Size for server volume in GB"
         },
         "WindowsVersion": {
             "default": "Server OS Version"
@@ -389,7 +389,7 @@
   },
   "Conditions" : {
     "EnablePublicFirewallRule" : { "Fn::Equals" : [{ "Ref" : "PublicFirewallProfileHole"}, "Yes"]},
-    "IsTrial" :                  { "Fn::Equals":  [{ "Ref" : "TableauServerLicenseKey", "" }]
+    "IsTrial" :                  { "Fn::Equals":  [ "", { "Ref" : "TableauServerLicenseKey"}]
     }
   },
   "Resources" : {

--- a/CloudFormation/public-sample-ssl-single-server.cfn
+++ b/CloudFormation/public-sample-ssl-single-server.cfn
@@ -133,8 +133,7 @@
     },
     "TableauServerLicenseKey" : {
       "Description" : "License Key",
-      "Type" : "String",
-      "MinLength" : "1"
+      "Type" : "String"
     },
     "TableauServerVolumeSize" : {
       "Description" : "Size of volume for server in GB; need at least 30 GB free for server installation",

--- a/CloudFormation/public-sample-ssl-single-server.cfn
+++ b/CloudFormation/public-sample-ssl-single-server.cfn
@@ -105,15 +105,6 @@
         "Description" : "The availability zone in which our server and storage volume reside",
         "Type": "AWS::EC2::AvailabilityZone::Name"
     },
-    "RunasPassword" : {
-      "Description" : "The password of the user which runs the service; blank for default",
-      "Type" : "String",
-      "NoEcho" : "true"
-    },
-    "RunasUser" : {
-      "Description" : "The name of the user which runs the service; blank for default",
-      "Type" : "String"
-    },
     "SourceCidrForRDP" : {
       "Description" : "IP Cidr from which you are likely to RDP into the instances. You can add rules later by modifying the created security groups e.g. 54.32.98.160/32",
       "Type" : "String",
@@ -219,7 +210,7 @@
         },
         {
             "Label" : { "default" : "Secrets" },
-            "Parameters" : ["RunasUser","RunasPassword","ContentAdminUser","ContentAdminPassword"]
+            "Parameters" : ["ContentAdminUser","ContentAdminPassword"]
         },
         {
             "Label" : { "default" : "Registration" },
@@ -301,12 +292,6 @@
         },
         "ResourceAvailabilityZone": {
             "default": "Target AZ"
-        },
-        "RunasPassword": {
-            "default": "Service runas password"
-        },
-        "RunasUser": {
-            "default": "Service runas user"
         },
         "SourceCidrForRDP": {
             "default": "Allowed CIDR for RDP access"
@@ -510,8 +495,6 @@
               },
               "c:\\tabsetup\\secrets.json" : {
                 "content" : {
-                    "runas_user" : {"Ref" : "RunasUser"},
-                    "runas_pass" : {"Ref" : "RunasPassword"},
                     "content_admin_user" : {"Ref" : "ContentAdminUser"},
                     "content_admin_pass" : {"Ref" : "ContentAdminPassword"}
                 }

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ Option|Argument|Required|Description
 --enablePublicFwRule||Optional|Use this to specify that a firewall rule to enable connections to the Gateway process (if configured to be created at all), should also be enabled on the Windows "public" profile. _If omitted, the firewall rule, if created at all, will default to the private and domain profiles only._
 --secretsFile|[FILE PATH]|**Required**|Path to a .json file (relative or absolute) that describes both the credentials of the Windows account that Tableau Server will run as, and the username/password of the initial admin user for Tableau Server.  See [Secrets File](#SecretsFile) for more information.
 --registrationFile|[FILE PATH]|**Required**|Path to a .json file (relative or absolute) describing the Tableau Server registration information. See [Server Registration File](#RegFile) for more information.
---licenseKey|[KEY]|**Required**|Your server license key, acquired through the usual channels.
+--licenseKey|[KEY]|**Required***|Your server license key, acquired through the usual channels.
+--trialLicense||**Required***|Use trial license (not valid for cluster setup)
 (installer executable)|[FILE PATH]|**Required**|The final argument to the script is simply the path, absolute or relative, to the Tableau Server installer executable, acquired through usual channels such as downloaded from the Tableau Website. _This script is only supported for use with Tableau Server v10.1 and higher._ 
+\* ***One and only one of --licenseKey or --trialLicense must be used***
 
 #### _upgrade_ mode
 


### PR DESCRIPTION
Add support for trial license; ScriptedInstaller added support for it, and the single-node sample CloudFormation template uses it.

Updated AMI IDs in all the templates.

Cleaned up all the templates a bit; got rid of useless defaults for parameters, cleaned up cruft w/wait conditions, other minor things
