### PR TITLE
support multiple license keys in linux/automated-installer

### DIFF
--- a/linux/automated-installer/automated-installer
+++ b/linux/automated-installer/automated-installer
@@ -250,7 +250,7 @@ check_arguments() {
         data_dir="${OPTARG}"
         ;;
       k)
-        license_key="${OPTARG}"
+        license_keys=$(echo ${license_keys} ${OPTARG}) # append and trim
         ;;
       s)
         secrets_file="${OPTARG}"
@@ -582,10 +582,12 @@ setup() {
   print "Setting up initial configuration..."
 
   print "Activating..."
-  if [ "$license_key" == "" ]; then
+  if [ "$license_keys" == "" ]; then
     run_tsm licenses activate --trial
-  else
-    run_tsm licenses activate --license-key "${license_key}"
+  else for license_key in $license_keys
+    do
+      run_tsm licenses activate --license-key "${license_key}"
+    done
   fi
 
   print "Registering product..."
@@ -657,7 +659,7 @@ main() {
   local registration_file=''
   local accept_eula_arg=''
   local force_arg=''
-  local license_key=''
+  local license_keys=''
   local group_username=''
   local running_username=''
   local bootstrap_file=''


### PR DESCRIPTION
To activate multiple keys, specify `-k` multiple times:
```
automated-installer -k key1 -k key2 ...
```

Backwards compatible.
If no `-k` specified (or only empty-string keys), it still applies trial license.