### PR TITLE
New fields in the registration file required in Tableau 2021.4

### DIFF
--- a/windows/tsm/SilentInstaller/registration.template.json
+++ b/windows/tsm/SilentInstaller/registration.template.json
@@ -11,5 +11,7 @@
   "city" : "[value]",
   "state" : "[value]",
   "zip" : "[value]",
-  "country" : "[value]"
+  "country" : "[value]",
+  "company_employees" : "[value]",
+  "opt_in" : "[value]"
 }


### PR DESCRIPTION
Tableau requires new fields in registration form. New fields were added between 2020.4 and 2021.4
company_employees - number
opt_in - true/false

https://help.tableau.com/current/offline/en-us/tableau_server_linux.pdf
https://help.tableau.com/current/desktopdeploy/en-us/desktop_deploy_automate.htm
Tableau documents that mention it.