### PR TITLE
Accept CSV list of license keys

### DIFF
--- a/linux/automated-installer/automated-installer
+++ b/linux/automated-installer/automated-installer
@@ -58,6 +58,7 @@ show_help() {
                                             When not set, the initialize-tsm script uses its default value.
 
     -k license-key                          Specify product key used to activate Tableau Server.
+                                            Can be a single key or CSV list to activate multiple keys.
                                             When not set, a trial license will be activated.
 
     -g                                      Do NOT add the current user to the "tsmadmin" administrative
@@ -583,7 +584,10 @@ setup() {
   if [ "$license_key" == "" ]; then
     run_tsm licenses activate --trial
   else
-    run_tsm licenses activate --license-key "${license_key}"
+    IFS="," read -r -a license_arr <<< "${license_key}"
+    for key in "${license_arr[@]}" ; do
+        run_tsm licenses activate --license-key "${key}"
+    done
   fi
 
   print "Registering product..."


### PR DESCRIPTION
To allow activating multiple license keys during Tableau Server installation, accept a CSV list for -k license-key option and iterate over entries